### PR TITLE
Serve built client from Express backend

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -29,16 +29,34 @@ if (!fs.existsSync(uploadsPath)) {
 }
 app.use('/uploads', express.static(uploadsPath));
 
-app.get('/', (req, res) => {
-  res.json({ message: 'CV. Jaya Kencana API' });
-});
-
 app.use('/api/auth', authRoutes);
 app.use('/api/company-profiles', companyProfileRoutes);
 app.use('/api/products', productRoutes);
 app.use('/api/projects', projectRoutes);
 app.use('/api/gallery', galleryRoutes);
 app.use('/api/messages', messageRoutes);
+
+app.get('/api', (req, res) => {
+  res.json({ message: 'CV. Jaya Kencana API' });
+});
+
+const clientBuildPath = path.join(__dirname, '..', 'client', 'dist');
+
+if (fs.existsSync(clientBuildPath)) {
+  app.use(express.static(clientBuildPath));
+
+  app.get('*', (req, res, next) => {
+    if (req.path.startsWith('/api') || req.path.startsWith('/uploads')) {
+      return next();
+    }
+
+    res.sendFile(path.join(clientBuildPath, 'index.html'));
+  });
+} else {
+  app.get('/', (req, res) => {
+    res.json({ message: 'CV. Jaya Kencana API' });
+  });
+}
 
 const bootstrap = async () => {
   try {


### PR DESCRIPTION
## Summary
- serve the production React build from the Express server when the dist folder is present
- fall back to the previous JSON message when the frontend build is unavailable
- ensure non-frontend routes such as /api and /uploads continue to behave normally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dca2cd613083269e72a128be63c6ce