### PR TITLE
Ensure CompanyProfiles schema includes legalDocument column

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ const helmet = require('helmet');
 const path = require('path');
 const fs = require('fs');
 const bcrypt = require('bcrypt');
+const { DataTypes } = require('sequelize');
 require('dotenv').config();
 
 const { sequelize, User, CompanyProfile } = require('./models');
@@ -58,9 +59,23 @@ if (fs.existsSync(clientBuildPath)) {
   });
 }
 
+const ensureCompanyProfileSchema = async () => {
+  const queryInterface = sequelize.getQueryInterface();
+  const tableDescription = await queryInterface.describeTable('CompanyProfiles');
+
+  if (!tableDescription.legalDocument) {
+    await queryInterface.addColumn('CompanyProfiles', 'legalDocument', {
+      type: DataTypes.STRING,
+      allowNull: true
+    });
+    console.log('Added legalDocument column to CompanyProfiles table');
+  }
+};
+
 const bootstrap = async () => {
   try {
     await sequelize.sync();
+    await ensureCompanyProfileSchema();
 
     const adminExists = await User.findOne({ where: { email: 'admin@jayakencana.co.id' } });
     if (!adminExists) {


### PR DESCRIPTION
## Summary
- ensure the API checks the CompanyProfiles table schema on startup and adds the missing legalDocument column when necessary
- import Sequelize DataTypes in the server bootstrap so the new schema migration helper can define the column type

## Testing
- not run (not available in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd1a96c9708326b7669e44a514f699