### PR TITLE
Fix contact info binding and enable multiple legal document uploads

### DIFF
--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -60,18 +60,24 @@ const About = () => {
 
         <section className="card" style={{ background: '#fff' }}>
           <h3>Legalitas Perusahaan</h3>
-          {profile?.legalDocument ? (
-            <div style={{ display: 'grid', gap: '0.5rem' }}>
+          {Array.isArray(profile?.legalDocument) && profile.legalDocument.length > 0 ? (
+            <div style={{ display: 'grid', gap: '0.75rem' }}>
               <p>Dokumen legalitas resmi kami tersedia untuk diunduh.</p>
-              <a
-                href={profile.legalDocument}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="primary-button"
-                style={{ justifySelf: 'flex-start' }}
-              >
-                Lihat Dokumen Legalitas
-              </a>
+              <ul style={{ display: 'grid', gap: '0.5rem', paddingLeft: '1.25rem', margin: 0 }}>
+                {profile.legalDocument.map((documentUrl, index) => (
+                  <li key={documentUrl}>
+                    <a
+                      href={documentUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="primary-button"
+                      style={{ justifySelf: 'flex-start' }}
+                    >
+                      Dokumen Legalitas {index + 1}
+                    </a>
+                  </li>
+                ))}
+              </ul>
             </div>
           ) : (
             <p>Informasi legalitas perusahaan akan segera tersedia.</p>

--- a/client/src/pages/Contact.jsx
+++ b/client/src/pages/Contact.jsx
@@ -1,10 +1,32 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import axios from 'axios';
 
 const Contact = () => {
   const [form, setForm] = useState({ name: '', email: '', subject: '', message: '' });
   const [status, setStatus] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchProfile = async () => {
+      try {
+        const { data } = await axios.get('/api/company-profiles');
+        if (isMounted && Array.isArray(data) && data.length > 0) {
+          setProfile(data[0]);
+        }
+      } catch (error) {
+        console.error('Failed to load company profile for contact page', error);
+      }
+    };
+
+    fetchProfile();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   const handleChange = (event) => {
     const { name, value } = event.target;
@@ -39,9 +61,9 @@ const Contact = () => {
           </p>
           <div className="card" style={{ marginTop: '2rem' }}>
             <h3>Informasi Kontak</h3>
-            <p>Alamat: Jl. Contoh No. 123, Jakarta</p>
-            <p>Telepon: +62 812-3456-7890</p>
-            <p>Email: info@jayakencana.co.id</p>
+            <p>Alamat: {profile?.address || 'Informasi alamat belum tersedia.'}</p>
+            <p>Telepon: {profile?.phone || 'Informasi telepon belum tersedia.'}</p>
+            <p>Email: {profile?.email || 'Informasi email belum tersedia.'}</p>
           </div>
         </div>
 

--- a/server/models/CompanyProfile.js
+++ b/server/models/CompanyProfile.js
@@ -48,8 +48,41 @@ const CompanyProfile = sequelize.define('CompanyProfile', {
     allowNull: true
   },
   legalDocument: {
-    type: DataTypes.STRING,
-    allowNull: true
+    type: DataTypes.TEXT,
+    allowNull: true,
+    get() {
+      const rawValue = this.getDataValue('legalDocument');
+      if (!rawValue) {
+        return [];
+      }
+
+      if (Array.isArray(rawValue)) {
+        return rawValue;
+      }
+
+      try {
+        const parsed = JSON.parse(rawValue);
+        if (Array.isArray(parsed)) {
+          return parsed;
+        }
+        return parsed ? [parsed] : [];
+      } catch (error) {
+        return [rawValue];
+      }
+    },
+    set(value) {
+      if (!value || (Array.isArray(value) && value.length === 0)) {
+        this.setDataValue('legalDocument', null);
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        this.setDataValue('legalDocument', JSON.stringify(value));
+        return;
+      }
+
+      this.setDataValue('legalDocument', JSON.stringify([value]));
+    }
   }
 });
 

--- a/server/routes/companyProfileRoutes.js
+++ b/server/routes/companyProfileRoutes.js
@@ -30,7 +30,7 @@ const storage = multer.diskStorage({
 const upload = multer({ storage });
 const uploadFields = upload.fields([
   { name: 'heroImage', maxCount: 1 },
-  { name: 'legalDocument', maxCount: 1 }
+  { name: 'legalDocuments', maxCount: 10 }
 ]);
 
 router.get('/', getProfiles);


### PR DESCRIPTION
## Summary
- load the company profile on the contact page so address, phone, and email mirror admin data
- allow uploading, retaining, and removing multiple legal documents through the admin UI and API
- render all available legal documents on the public about page

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68dd1f2fdfa083268ea629776abfdc51