### PR TITLE
Load footer contact info from company profile

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -1,20 +1,46 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
 const Footer = () => {
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchProfile = async () => {
+      try {
+        const { data } = await axios.get('/api/company-profiles');
+        if (isMounted && Array.isArray(data) && data.length > 0) {
+          setProfile(data[0]);
+        }
+      } catch (error) {
+        console.error('Failed to load footer contact information', error);
+      }
+    };
+
+    fetchProfile();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <footer className="footer">
       <div className="container">
         <div className="footer__content">
           <div>
-            <h3>CV. Jaya Kencana</h3>
+            <h3>{profile?.companyName || 'CV. Jaya Kencana'}</h3>
             <p>
-              Solusi profesional untuk konstruksi dan pengadaan industri. Kami siap
-              mendukung keberhasilan proyek Anda.
+              {profile?.about ||
+                'Solusi profesional untuk konstruksi dan pengadaan industri. Kami siap mendukung keberhasilan proyek Anda.'}
             </p>
           </div>
           <div>
             <h4>Kontak</h4>
-            <p>Jl. Contoh No. 123, Jakarta</p>
-            <p>+62 812-3456-7890</p>
-            <p>info@jayakencana.co.id</p>
+            <p>{profile?.address || 'Alamat perusahaan belum tersedia.'}</p>
+            <p>{profile?.phone || 'Nomor telepon belum tersedia.'}</p>
+            <p>{profile?.email || 'Email belum tersedia.'}</p>
           </div>
           <div>
             <h4>Jam Operasional</h4>
@@ -23,7 +49,9 @@ const Footer = () => {
           </div>
         </div>
         <div className="footer__bottom">
-          <p>&copy; {new Date().getFullYear()} CV. Jaya Kencana. All rights reserved.</p>
+          <p>
+            &copy; {new Date().getFullYear()} {profile?.companyName || 'CV. Jaya Kencana'}. All rights reserved.
+          </p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- fetch the company profile data when rendering the footer
- display footer contact information from the stored company profile with sensible fallbacks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd24c5fb88832682b14e807d5017fc