### PR TITLE
Use WhatsApp contact instead of price for products

### DIFF
--- a/client/src/pages/Products.jsx
+++ b/client/src/pages/Products.jsx
@@ -17,25 +17,62 @@ const Products = () => {
     fetchProducts();
   }, []);
 
+  const getWhatsAppDetails = (rawValue) => {
+    if (!rawValue && rawValue !== 0) return null;
+
+    const digits = String(rawValue).replace(/\D/g, '');
+    if (!digits) return null;
+
+    const normalized = digits.startsWith('62')
+      ? digits
+      : digits.startsWith('0')
+      ? `62${digits.slice(1)}`
+      : `62${digits}`;
+
+    const display = normalized.startsWith('62') ? `+${normalized}` : normalized;
+
+    return {
+      link: `https://wa.me/${normalized}`,
+      display
+    };
+  };
+
   return (
     <main className="section">
       <div className="container">
         <h1 className="section-title">Produk Kami</h1>
         <div className="card-grid">
-          {products.map((product) => (
-            <div key={product.id} className="card">
-              {product.imageUrl && (
-                <img
-                  src={product.imageUrl}
-                  alt={product.name}
-                  style={{ borderRadius: '12px', height: '200px', objectFit: 'cover' }}
-                />
-              )}
-              <h3>{product.name}</h3>
-              <p>{product.description}</p>
-              {product.price && <strong>Rp {Number(product.price).toLocaleString('id-ID')}</strong>}
-            </div>
-          ))}
+          {products.map((product) => {
+            const whatsapp = getWhatsAppDetails(product.price);
+
+            return (
+              <div key={product.id} className="card">
+                {product.imageUrl && (
+                  <img
+                    src={product.imageUrl}
+                    alt={product.name}
+                    style={{ borderRadius: '12px', height: '200px', objectFit: 'cover' }}
+                  />
+                )}
+                <h3>{product.name}</h3>
+                <p>{product.description}</p>
+                {whatsapp && (
+                  <div style={{ display: 'grid', gap: '0.5rem' }}>
+                    <span style={{ fontWeight: 600 }}>Kontak: {whatsapp.display}</span>
+                    <a
+                      href={whatsapp.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="primary-button"
+                      style={{ textAlign: 'center' }}
+                    >
+                      Hubungi via WhatsApp
+                    </a>
+                  </div>
+                )}
+              </div>
+            );
+          })}
           {products.length === 0 && <p>Belum ada data produk.</p>}
         </div>
       </div>

--- a/client/src/pages/admin/ProductsAdmin.jsx
+++ b/client/src/pages/admin/ProductsAdmin.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 
-const initialState = { name: '', description: '', price: '' };
+const initialState = { name: '', description: '', contactNumber: '' };
 
 const ProductsAdmin = ({ token }) => {
   const [products, setProducts] = useState([]);
@@ -9,6 +9,25 @@ const ProductsAdmin = ({ token }) => {
   const [image, setImage] = useState(null);
   const [editingId, setEditingId] = useState(null);
   const [status, setStatus] = useState(null);
+
+  const getWhatsAppDetails = (value) => {
+    if (!value && value !== 0) return null;
+
+    const digits = String(value).replace(/\D/g, '');
+    if (!digits) return null;
+
+    const normalized = digits.startsWith('62')
+      ? digits
+      : digits.startsWith('0')
+      ? `62${digits.slice(1)}`
+      : `62${digits}`;
+
+    return {
+      normalized,
+      display: `+${normalized}`,
+      link: `https://wa.me/${normalized}`
+    };
+  };
 
   const fetchProducts = async () => {
     try {
@@ -25,7 +44,9 @@ const ProductsAdmin = ({ token }) => {
 
   const handleChange = (event) => {
     const { name, value } = event.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
+    const nextValue =
+      name === 'contactNumber' ? value.replace(/\D/g, '') : value;
+    setForm((prev) => ({ ...prev, [name]: nextValue }));
   };
 
   const handleSubmit = async (event) => {
@@ -35,7 +56,7 @@ const ProductsAdmin = ({ token }) => {
       const formData = new FormData();
       formData.append('name', form.name);
       formData.append('description', form.description);
-      formData.append('price', form.price);
+      formData.append('price', form.contactNumber);
       if (image) {
         formData.append('image', image);
       }
@@ -69,7 +90,7 @@ const ProductsAdmin = ({ token }) => {
     setForm({
       name: product.name || '',
       description: product.description || '',
-      price: product.price || ''
+      contactNumber: (product.price && String(product.price).replace(/\D/g, '')) || ''
     });
     setEditingId(product.id);
     setImage(null);
@@ -104,8 +125,13 @@ const ProductsAdmin = ({ token }) => {
             <textarea name="description" rows="3" value={form.description} onChange={handleChange} />
           </div>
           <div>
-            <label>Harga</label>
-            <input name="price" value={form.price} onChange={handleChange} />
+            <label>Kontak WhatsApp</label>
+            <input
+              name="contactNumber"
+              value={form.contactNumber}
+              onChange={handleChange}
+              placeholder="Contoh: 628123456789"
+            />
           </div>
           <div>
             <label>Foto Produk</label>
@@ -121,33 +147,50 @@ const ProductsAdmin = ({ token }) => {
       <div className="card" style={{ background: '#fff' }}>
         <h2>Daftar Produk</h2>
         <div className="card-grid">
-          {products.map((product) => (
-            <div key={product.id} className="card" style={{ boxShadow: 'none', border: '1px solid #e5e7eb' }}>
-              {product.imageUrl && (
-                <img
-                  src={product.imageUrl}
-                  alt={product.name}
-                  style={{ borderRadius: '12px', height: '160px', objectFit: 'cover' }}
-                />
-              )}
-              <h3>{product.name}</h3>
-              <p>{product.description}</p>
-              {product.price && <strong>Rp {Number(product.price).toLocaleString('id-ID')}</strong>}
-              <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
-                <button type="button" className="primary-button" onClick={() => handleEdit(product)}>
-                  Edit
-                </button>
-                <button
-                  type="button"
-                  className="primary-button"
-                  style={{ background: '#dc2626' }}
-                  onClick={() => handleDelete(product.id)}
-                >
-                  Hapus
-                </button>
+          {products.map((product) => {
+            const whatsapp = getWhatsAppDetails(product.price);
+
+            return (
+              <div key={product.id} className="card" style={{ boxShadow: 'none', border: '1px solid #e5e7eb' }}>
+                {product.imageUrl && (
+                  <img
+                    src={product.imageUrl}
+                    alt={product.name}
+                    style={{ borderRadius: '12px', height: '160px', objectFit: 'cover' }}
+                  />
+                )}
+                <h3>{product.name}</h3>
+                <p>{product.description}</p>
+                {whatsapp && (
+                  <div style={{ display: 'grid', gap: '0.5rem' }}>
+                    <strong>Kontak WhatsApp: {whatsapp.display}</strong>
+                    <a
+                      href={whatsapp.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="primary-button"
+                      style={{ textAlign: 'center' }}
+                    >
+                      Kirim Pesan
+                    </a>
+                  </div>
+                )}
+                <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+                  <button type="button" className="primary-button" onClick={() => handleEdit(product)}>
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className="primary-button"
+                    style={{ background: '#dc2626' }}
+                    onClick={() => handleDelete(product.id)}
+                  >
+                    Hapus
+                  </button>
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
           {products.length === 0 && <p>Belum ada produk.</p>}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the product price display with a WhatsApp contact call-to-action on the public products page
- update the admin form to collect WhatsApp numbers, sanitise inputs, and reuse the contact button inside the admin listing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11778e88483268f43662ffd4acd4d