### PR TITLE
Adjust image rendering to avoid cropping

### DIFF
--- a/client/src/pages/Gallery.jsx
+++ b/client/src/pages/Gallery.jsx
@@ -28,7 +28,14 @@ const Gallery = () => {
                 <img
                   src={item.imageUrl}
                   alt={item.title}
-                  style={{ borderRadius: '12px', height: '200px', objectFit: 'cover' }}
+                  style={{
+                    borderRadius: '12px',
+                    width: '100%',
+                    height: 'auto',
+                    maxHeight: '220px',
+                    objectFit: 'contain',
+                    backgroundColor: '#f8fafc'
+                  }}
                 />
               )}
               <h3>{item.title}</h3>

--- a/client/src/pages/Portfolio.jsx
+++ b/client/src/pages/Portfolio.jsx
@@ -49,7 +49,14 @@ const Portfolio = () => {
                         <img
                           src={project.imageUrl}
                           alt={project.title}
-                          style={{ borderRadius: '12px', height: '180px', objectFit: 'cover' }}
+                          style={{
+                            borderRadius: '12px',
+                            width: '100%',
+                            height: 'auto',
+                            maxHeight: '200px',
+                            objectFit: 'contain',
+                            backgroundColor: '#f8fafc'
+                          }}
                         />
                       )}
                       <h3>{project.title}</h3>

--- a/client/src/pages/Products.jsx
+++ b/client/src/pages/Products.jsx
@@ -51,7 +51,14 @@ const Products = () => {
                   <img
                     src={product.imageUrl}
                     alt={product.name}
-                    style={{ borderRadius: '12px', height: '200px', objectFit: 'cover' }}
+                    style={{
+                      borderRadius: '12px',
+                      width: '100%',
+                      height: 'auto',
+                      maxHeight: '220px',
+                      objectFit: 'contain',
+                      backgroundColor: '#f8fafc'
+                    }}
                   />
                 )}
                 <h3>{product.name}</h3>

--- a/client/src/pages/admin/GalleryAdmin.jsx
+++ b/client/src/pages/admin/GalleryAdmin.jsx
@@ -117,7 +117,14 @@ const GalleryAdmin = ({ token }) => {
                 <img
                   src={item.imageUrl}
                   alt={item.title}
-                  style={{ borderRadius: '12px', height: '160px', objectFit: 'cover' }}
+                  style={{
+                    borderRadius: '12px',
+                    width: '100%',
+                    height: 'auto',
+                    maxHeight: '200px',
+                    objectFit: 'contain',
+                    backgroundColor: '#f8fafc'
+                  }}
                 />
               )}
               <h3>{item.title}</h3>

--- a/client/src/pages/admin/ProductsAdmin.jsx
+++ b/client/src/pages/admin/ProductsAdmin.jsx
@@ -157,7 +157,14 @@ const ProductsAdmin = ({ token }) => {
                   <img
                     src={product.imageUrl}
                     alt={product.name}
-                    style={{ borderRadius: '12px', height: '160px', objectFit: 'cover' }}
+                    style={{
+                      borderRadius: '12px',
+                      width: '100%',
+                      height: 'auto',
+                      maxHeight: '200px',
+                      objectFit: 'contain',
+                      backgroundColor: '#f8fafc'
+                    }}
                   />
                 )}
                 <h3>{product.name}</h3>

--- a/client/src/pages/admin/ProjectsAdmin.jsx
+++ b/client/src/pages/admin/ProjectsAdmin.jsx
@@ -130,7 +130,14 @@ const ProjectsAdmin = ({ token }) => {
                 <img
                   src={project.imageUrl}
                   alt={project.title}
-                  style={{ borderRadius: '12px', height: '160px', objectFit: 'cover' }}
+                  style={{
+                    borderRadius: '12px',
+                    width: '100%',
+                    height: 'auto',
+                    maxHeight: '200px',
+                    objectFit: 'contain',
+                    backgroundColor: '#f8fafc'
+                  }}
                 />
               )}
               <h3>{project.title}</h3>


### PR DESCRIPTION
## Summary
- ensure gallery, portfolio, and product cards render images at full aspect ratio without cropping
- align admin previews for gallery, products, and projects to match non-cropped display and neutral background

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e12185482c83269245f408fa7acdf7